### PR TITLE
Bug fix for sin, cos and tan

### DIFF
--- a/dist/functions/_cos.scss
+++ b/dist/functions/_cos.scss
@@ -4,7 +4,8 @@
 //     cos(0.7854) // 0.70711
 //     cos(45deg)  // 0.70711
 @function cos ($x) {
-    $x: unitless-rad($x);
+    $PI: 3.141592653589793;
+    $x: unitless-rad($x) % ($PI*2);
     $ret: 0;
     @for $n from 0 to 24 {
         $ret: $ret + pow(-1, $n) * pow($x, 2 * $n) / fact(2 * $n);


### PR DESCRIPTION
sin(100) returns -7208436636117832000000000000000000 without this fix.

Stumbled upon this bug when doing for-loops with trigonometric functions. Have a nice day!