### PR TITLE
some performance improvements (and other things)

### DIFF
--- a/dist/functions/_cos.scss
+++ b/dist/functions/_cos.scss
@@ -5,9 +5,11 @@
 //     cos(45deg)  // 0.70711
 @function cos ($x) {
     $x: unitless-rad($x) % ($PI * 2);
-    $ret: 0;
-    @for $n from 0 to 24 {
-        $ret: $ret + pow(-1, $n) * pow($x, 2 * $n) / fact(2 * $n);
+    $ret: 1;
+    $i: 1;
+    @for $n from 1 to 24 {
+        $i: $i * -1 * $x * $x / (2 * $n) / (2 * $n - 1);
+        $ret: $ret + $i;
     }
     @return $ret;
 }

--- a/dist/functions/_exp.scss
+++ b/dist/functions/_exp.scss
@@ -4,11 +4,5 @@
 //     exp(1)  // 2.71828
 //     exp(-1) // 0.36788
 @function exp ($x) {
-    $ret: 0;
-    $i: 1;
-    @for $n from 0 to 24 {
-        $ret: $ret + $i;
-        $i: $i * $x / ($n + 1);
-    }
-    @return $ret;
+    @return pow($E, $x);
 }

--- a/dist/functions/_exp.scss
+++ b/dist/functions/_exp.scss
@@ -5,8 +5,10 @@
 //     exp(-1) // 0.36788
 @function exp ($x) {
     $ret: 0;
+    $i: 1;
     @for $n from 0 to 24 {
-        $ret: $ret + pow($x, $n) / fact($n);
+        $ret: $ret + $i;
+        $i: $i * $x / ($n + 1);
     }
     @return $ret;
 }

--- a/dist/functions/_log.scss
+++ b/dist/functions/_log.scss
@@ -6,19 +6,21 @@
 //     log(10)    // 2.30259
 //     log(2, 10) // 0.30103
 @function log ($x, $b: null) {
-    @if $b == null {
-        @return _log($x);
-    } @else {
-        @return _log($x) / _log($b);
+    @if $b != null {
+        @return log($x) / log($b);
     }
-}
 
-@function _log ($x) {
     @if $x <= 0 {
         @return 0 / 0;
     }
     $k: nth(frexp($x / $SQRT2), 2);
     $x: $x / ldexp(1, $k);
+
+    @return $LN2 * $k + _log($x);
+}
+
+// a good aproximation for $x close to 1
+@function _log ($x) {
     $x: ($x - 1) / ($x + 1);
     $x2: $x * $x;
     $i: 1;
@@ -30,5 +32,5 @@
         $sp: $s;
         $s: $s + $x / $i;
     }
-    @return $LN2 * $k + 2 * $s;
+    @return 2 * $s;
 }

--- a/dist/functions/_pow.scss
+++ b/dist/functions/_pow.scss
@@ -23,10 +23,14 @@
         }
         @return if($s != 0, 1 / $r, $r);
     } @else {
-        @return _exp(log($base) * $exp);
+        $expint: floor($exp);
+        $r1: pow($base, $expint);
+        $r2: _exp(log($base) * ($exp - $expint));
+        @return $r1 * $r2;
     }
 }
 
+// A good approximation for $x close to 0.
 @function _exp ($x) {
     $ret: 0;
     $i: 1;

--- a/dist/functions/_pow.scss
+++ b/dist/functions/_pow.scss
@@ -23,6 +23,16 @@
         }
         @return if($s != 0, 1 / $r, $r);
     } @else {
-        @return exp(log($base) * $exp);
+        @return _exp(log($base) * $exp);
     }
+}
+
+@function _exp ($x) {
+    $ret: 0;
+    $i: 1;
+    @for $n from 0 to 24 {
+        $ret: $ret + $i;
+        $i: $i * $x / ($n + 1);
+    }
+    @return $ret;
 }

--- a/dist/functions/_pow.scss
+++ b/dist/functions/_pow.scss
@@ -22,6 +22,8 @@
             $base: $base * $base;
         }
         @return if($s != 0, 1 / $r, $r);
+    } @else if $base == 0 and $exp > 0 {
+        @return 0;
     } @else {
         $expint: floor($exp);
         $r1: pow($base, $expint);

--- a/dist/functions/_sqrt.scss
+++ b/dist/functions/_sqrt.scss
@@ -10,7 +10,7 @@
     }
     $ret: 1;
     @for $i from 1 through 24 {
-        $ret: $ret - (pow($ret, 2) - $x) / (2 * $ret);
+        $ret: $ret - ($ret * $ret - $x) / (2 * $ret);
     }
     @return $ret;
 }

--- a/test/functions/_cos.scss
+++ b/test/functions/_cos.scss
@@ -1,6 +1,9 @@
 @include describe("Cos") {
   @include it("should calculate the cosine of a number") {
-    @include should(expect( cos(0.7854) ), to( be-close-to( 0.70711, 5 )));
-    @include should(expect( cos(45deg)  ), to( be-close-to( 0.70711, 5 )));
+    @include should(expect( cos(0.7854)   ), to( be-close-to( 0.70711, 5 )));
+    @include should(expect( cos(45deg)    ), to( be-close-to( 0.70711, 5 )));
+    @include should(expect( cos(315deg)   ), to( be-close-to( 0.70711, 5 )));
+    @include should(expect( cos(3645deg)  ), to( be-close-to( 0.70711, 5 )));
+    @include should(expect( cos(-3645deg) ), to( be-close-to( 0.70711, 5 )));
   }
 }

--- a/test/functions/_exp.scss
+++ b/test/functions/_exp.scss
@@ -6,4 +6,12 @@
   @include it("should calculate negative exponents of eulers constant") {
     @include should(expect( exp(-1) ), to( be-close-to( 0.36788, 5 )));
   }
+
+  @include it("should calculate large exponents of eulers constant") {
+    @include should(expect( exp(10) ), to( be-close-to( 22026.46579, 5 )));
+  }
+
+  @include it("should calculate large fractional exponents of eulers constant") {
+    @include should(expect( exp(10.5) ), to( be-close-to( 36315.50267, 5 )));
+  }
 }

--- a/test/functions/_log.scss
+++ b/test/functions/_log.scss
@@ -4,4 +4,12 @@
     @include should(expect( log(10) ), to( be-close-to( 2.30259, 5 )));
     @include should(expect( log(2, 10) ), to( be-close-to( 0.30103, 5 )));
   }
+
+  @include it("should calculate the natural logarithm of a large fractional number") {
+    @include should(expect( log(12345.678)  ), to( be-close-to( 9.421061, 5 )));
+  }
+
+  @include it("should calculate the natural logarithm of a small fractional number") {
+    @include should(expect( log(0.0001)  ), to( be-close-to( -9.210340, 5 )));
+  }
 }

--- a/test/functions/_pow.scss
+++ b/test/functions/_pow.scss
@@ -3,6 +3,12 @@
     @include should(expect( pow(4,  2) ), to( equal( 16 )));
   }
 
+  @include it("should handle 0 correctly") {
+    @include should(expect( pow(0,   0) ), to( equal( 1 )));
+    @include should(expect( pow(3.5, 0) ), to( equal( 1 )));
+    @include should(expect( pow(0, 3.5) ), to( equal( 0 )));
+  }
+
   @include it("should calculate negative exponents") {
     @include should(expect( pow(4, -2) ), to( equal( 0.0625 )));
   }

--- a/test/functions/_sqrt.scss
+++ b/test/functions/_sqrt.scss
@@ -2,5 +2,6 @@
   @include it("should calculate square roots") {
     @include should(expect( sqrt(2) ), to( be-close-to( 1.41421, 5 )));
     @include should(expect( sqrt(5) ), to( be-close-to( 2.23607, 5 )));
+    @include should(expect( sqrt(12345.67) ), to( be-close-to( 111.11107, 5 )));
   }
 }


### PR DESCRIPTION
I maintain a very similar library to this at https://github.com/xi/sass-planifolia. As mathsass seems to be much more popular, I plan to deprecate my code and contribute to this project in the future. As a first step, I tried to port some optimizations, especially for large numbers.

The most interesting optimization is probably the one from c651a3bd84: The taylor expansion this library is based on converge rapidly close to specific input values, but much slower for values that are far off. Both `log()` and `cos()` mitigate this by converting the input value before handing it to the taylor expansion. `exp()` did not do this.

I did not do in-depth performance testing. However, I used the following script as a simple benchmark:

```sass
@import 'dist/math';

@for $i from 1 to 1000 {
	$x: sqrt($i / 3);
	$x: exp($i / 3);
	$x: cos($i / 3);
}
```

```sh
$ git checkout master
$ time node-sass perf.scss 
real	0m11.559s
user	0m11.464s
sys	0m0.096s

$ git checkout improve-performance
$ time node-sass perf.scss 
real	0m1.178s
user	0m1.112s
sys	0m0.080s
```