### PR TITLE
add support for other angle units

### DIFF
--- a/dist/helpers/_unitless-rad.scss
+++ b/dist/helpers/_unitless-rad.scss
@@ -1,13 +1,4 @@
 // Convert to unitless rad
 @function unitless-rad ($angle) {
-    @if unitless($angle) {
-        @return $angle;
-    } @else if unit($angle) == rad {
-        @return $angle / 1rad;
-    } @else if unit($angle) == deg {
-        @return deg-to-rad($angle, false);
-    } @else if type-of($angle) != number or not unitless($angle) {
-        @warn "#{ $angle } is not a valid number.";
-        @return $angle;
-    }
+    @return (0rad + $angle) / 1rad;
 }

--- a/test/helpers/_unitless-rad.scss
+++ b/test/helpers/_unitless-rad.scss
@@ -20,4 +20,18 @@
     @include should(expect( unitless-rad(180deg) ), to( be-close-to( 3.14159, 5 )));
     @include should(expect( unitless-rad(360deg) ), to( be-close-to( 6.28319, 5 )));
   }
+
+  @include it("should convert turns to radians without unit") {
+    @include should(expect( unitless-rad(.1turn) ), to( be-close-to( 0.62832, 5 )));
+    @include should(expect( unitless-rad(.2turn) ), to( be-close-to( 1.25664, 4 )));
+    @include should(expect( unitless-rad(.5turn) ), to( be-close-to( 3.14159, 5 )));
+    @include should(expect( unitless-rad(1turn)  ), to( be-close-to( 6.28319, 5 )));
+  }
+
+  @include it("should convert gradians to radians without unit") {
+    @include should(expect( unitless-rad(1grad)   ), to( be-close-to( 0.01571, 5 )));
+    @include should(expect( unitless-rad(10grad)  ), to( be-close-to( 0.15708, 4 )));
+    @include should(expect( unitless-rad(200grad) ), to( be-close-to( 3.14159, 5 )));
+    @include should(expect( unitless-rad(400grad) ), to( be-close-to( 6.28319, 5 )));
+  }
 }


### PR DESCRIPTION
Fixes #5.

Not that I simplified `unitless-rad()` by using native native fixed unit conversion. This was suggested to me in https://github.com/xi/sass-planifolia/issues/1.

Note that invlid input like `unitless-rad(2em)` will still produce warnings: "Incompatible units: 'em' and 'rad'."