### PR TITLE
Fix rounding error of negative exponents

### DIFF
--- a/dist/functions/_pow.scss
+++ b/dist/functions/_pow.scss
@@ -11,7 +11,7 @@
         $r: 1;
         $s: 0;
         @if $exp < 0 {
-            $exp: $exp * -1;
+            $exp: ceil($exp * -1);
             $s: 1;
         }
         @while $exp > 0 {

--- a/test/functions/_pow.scss
+++ b/test/functions/_pow.scss
@@ -11,6 +11,7 @@
 
   @include it("should calculate negative exponents") {
     @include should(expect( pow(4, -2) ), to( equal( 0.0625 )));
+    @include should(expect( pow(4, 10 * (0.8 - 1)) ), to( equal( 0.0625 )));
   }
 
   @include it("should calculate decimal exponents") {


### PR DESCRIPTION
`pow(4, 10 * (0.8 - 1));` expects 0.0625, but return 1.

Maybe,
```scss
// dist/functions/_pow.scss
@if $exp < 0 {
    $exp: $exp * -1; //=> 1.9999999999 🤔
    $s: 1;
}
```

So, 👇
```scss
@if $exp < 0 {
    $exp: ceil($exp * -1); //=> 2
    $s: 1;
}
```

Try this:
```scss
$exp: 10 * (0.8 - 1) * -1; //=> 2 ? maybe 1.9999999999
$int: floor($exp); //=> 2 ? but 1
@debug $exp, $int, $exp - $int; //=> 2, 1, 1 😩
```